### PR TITLE
Add max_retries setting for failing tasks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 **Added**
 
+- #2 Add max_retries setting for failing tasks
 - #1 Add sample guard to prevent transitions when queued analyses
 
 **Changed**

--- a/README.rst
+++ b/README.rst
@@ -129,7 +129,6 @@ Empty queue
       "current": null,
       "processed": {},
       "container": "/senaite/bika_setup",
-      "speed": -1,
       "id": "senaite.queue.main.storage"
     }
 
@@ -191,7 +190,6 @@ under `processed` key:
       "name": "task_action_submit"
     },
     "container": "/senaite/bika_setup",
-    "speed": 2,
     "id": "senaite.queue.main.storage"
     }
 
@@ -239,7 +237,6 @@ but an empty list is displayed in `tasks`:
     },
     "processed": null,
     "container": "/senaite/bika_setup",
-    "speed": 2,
     "id": "senaite.queue.main.storage"
     }
 
@@ -288,7 +285,6 @@ inside `tasks` attribute:
     "current": null,
     "processed": {},
     "container": "/senaite/bika_setup",
-    "speed": -1,
     "id": "senaite.queue.main.storage"
     }
 

--- a/src/senaite/queue/adapters.py
+++ b/src/senaite/queue/adapters.py
@@ -109,7 +109,6 @@ class QueuedActionTaskAdapter(QueuedTaskAdapter):
         else:
             # There are no more items to queue, all items queued for this
             # context have been transitioned already
-            noLongerProvides(self.context, IQueued)
             self.storage.flush()
 
         logger.info("*** Processed: {}/{}".format(len(chunks[0]), num_objects))
@@ -127,7 +126,7 @@ class QueuedActionTaskAdapter(QueuedTaskAdapter):
                 logger.error("Object not found for UID {}".format(uid))
                 return
 
-            # Remove the marker interface
+            # Remove the marker interface to ensure the object can transition
             noLongerProvides(obj, IQueued)
 
             # Do the action
@@ -182,7 +181,6 @@ class QueuedAssignAnalysesTaskAdapter(QueuedTaskAdapter):
         else:
             # There are no more items to queue, all items queued for this
             # context have been transitioned already
-            noLongerProvides(self.context, IQueued)
             self.storage.flush()
 
         logger.info("*** Processed: {}/{}".format(len(chunks[0]), num_objects))
@@ -216,7 +214,7 @@ class QueuedAssignAnalysesTaskAdapter(QueuedTaskAdapter):
             # Get the suitable slot for this analysis
             slot = self.get_slot_for(analysis, wst)
 
-            # Remove the marker interface
+            # Remove the marker interface so the object can be transitioned
             noLongerProvides(analysis, IQueued)
 
             # Add the analysis

--- a/src/senaite/queue/api.py
+++ b/src/senaite/queue/api.py
@@ -157,3 +157,18 @@ def get_max_seconds_unlock():
     finished before being considered as failed
     """
     return get_registry_record("max_seconds_unlock", default=600)
+
+
+def get_max_retries():
+    """Returns the number of times a task will be re-queued before being
+    considered as failed and removed from the queue
+    """
+    max_retries = get_registry_record("senaite.queue.max_retries")
+    return to_int(max_retries, 5)
+
+
+def set_max_retries(retries):
+    """Sets the number of times a task will be re-queued before being
+    considered as failed and removed from the queue
+    """
+    ploneapi.portal.set_registry_record("senaite.queue.max_retries", retries)

--- a/src/senaite/queue/controlpanel.py
+++ b/src/senaite/queue/controlpanel.py
@@ -40,6 +40,17 @@ class IQueueControlPanel(Interface):
         required=True,
     )
 
+    max_retries = schema.Int(
+        title=_(u"Maximum retries"),
+        description=_(
+            "Number of times a task will be re-queued before being considered "
+            "as failed and removed from the queue. A value of 0 disables the"
+            "re-queue of failing tasks."
+        ),
+        default=5,
+        required=True,
+    )
+
     task_assign_analyses = schema.Int(
         title=_(u"Number of analyses to assign per task"),
         description=_(

--- a/src/senaite/queue/queue.py
+++ b/src/senaite/queue/queue.py
@@ -19,11 +19,12 @@
 # Some rights reserved, see README and LICENSE.
 
 from senaite.queue import api
-from senaite.queue.interfaces import IQueued
 from senaite.queue.storage import ActionQueueStorage
 from senaite.queue.storage import QueueStorageTool
+from senaite.queue.storage import QueueTask
 from senaite.queue.storage import WorksheetQueueStorage
-from zope.interface import alsoProvides
+
+from bika.lims.utils import tmpID
 
 
 def queue_action(context, request, action, objects):
@@ -62,9 +63,5 @@ def queue_task(name, request, context):
     """Adds a task to general queue storage
     """
     queue = QueueStorageTool()
-    queued = queue.append(name, request, context)
-
-    # Mark context as queued and reindex
-    if not IQueued.providedBy(context):
-        alsoProvides(context, IQueued)
-    return queued
+    task = QueueTask(name, request, context, tmpID())
+    return queue.append(task)

--- a/src/senaite/queue/tests/doctests/TaskFailure.rst
+++ b/src/senaite/queue/tests/doctests/TaskFailure.rst
@@ -1,0 +1,134 @@
+Queued task failure
+===================
+
+When a queued task fails, the system re-queues the task as many times as set
+in the `max_retries` setting from the registry before considering the task
+as failed.
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t TaskFailure
+
+Test Setup
+----------
+
+Needed imports:
+
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+    >>> from senaite.queue import api
+    >>> from senaite.queue.interfaces import IQueued
+    >>> from senaite.queue.tests import utils as test_utils
+    >>> from bika.lims.workflow import doActionFor
+    >>> from zope.interface import alsoProvides
+    >>> from zope.interface import noLongerProvides
+
+Functional Helpers:
+
+    >>> def new_samples(num_analyses):
+    ...     samples = []
+    ...     for num in range(num_analyses):
+    ...         sample = test_utils.create_sample([Cu], client, contact,
+    ...                                           sampletype, receive=True)
+    ...         samples.append(sample)
+    ...     return samples
+
+    >>> def get_analyses_from(samples):
+    ...     analyses = []
+    ...     for sample in samples:
+    ...         analyses.extend(sample.getAnalyses(full_objects=True))
+    ...     return analyses
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = api.get_setup()
+
+Create some basic objects for the test:
+
+    >>> setRoles(portal, TEST_USER_ID, ['Manager',])
+    >>> client = api.create(portal.clients, "Client", Name="Happy Hills", ClientID="HH", MemberDiscountApplies=True)
+    >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
+    >>> sampletype = api.create(setup.bika_sampletypes, "SampleType", title="Water", Prefix="W")
+    >>> labcontact = api.create(setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.bika_departments, "Department", title="Chemistry", Manager=labcontact)
+    >>> category = api.create(setup.bika_analysiscategories, "AnalysisCategory", title="Metals", Department=department)
+    >>> Cu = api.create(setup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="15", Category=category.UID(), Accredited=True)
+
+Failure while assigning analyses to a Worksheet
+-----------------------------------------------
+
+Set the number of max retries on failure:
+
+    >>> api.set_max_retries(3)
+
+Set the number of analyses to be transitioned in a single queued task:
+
+    >>> task_name = "task_assign_analyses"
+    >>> api.set_chunk_size(task_name, 5)
+    >>> api.get_chunk_size(task_name)
+    5
+
+Create 10 Samples with 1 analysis each and add the analyses to a worksheet:
+
+    >>> samples = new_samples(10)
+    >>> analyses = get_analyses_from(samples)
+    >>> worksheet = api.create(portal.worksheets, "Worksheet")
+    >>> worksheet.addAnalyses(analyses)
+
+Only the first chunk of analyses has been transitioned non-async:
+
+    >>> transitioned = test_utils.filter_by_state(analyses, "assigned")
+    >>> len(transitioned)
+    5
+
+Submit the result of one of the remaining analyses to be assigned. Note this
+action is not possible through the web interface because analyses that implement
+the IQueued interface appear disabled in listings:
+
+    >>> non_transitioned = filter(lambda an: IQueued.providedBy(an), analyses)
+    >>> black_sheep = non_transitioned[0]
+    >>> black_sheep.aq_parent.manage_delObjects([black_sheep.getId()])
+
+Since we've submitted a result for one analysis, the system won't be able to
+process the task successfully:
+
+    >>> "No object found for UID" in test_utils.dispatch()
+    True
+    >>> transitioned = test_utils.filter_by_state(analyses, "assigned")
+    >>> len(transitioned) < 10
+    True
+
+And the task is re-queued automatically:
+
+    >>> queue = test_utils.get_queue_tool()
+    >>> task = queue.tasks[0]
+    >>> task.retries
+    1
+
+If we retry, the number of retries increases:
+
+    >>> "No object found for UID" in test_utils.dispatch()
+    True
+    >>> queue.tasks[0].retries
+    2
+
+Until we reach the maximum of retries:
+
+    >>> "No object found for UID" in test_utils.dispatch()
+    True
+    >>> len(queue.tasks)
+    1
+    >>> queue.tasks[0].retries
+    3
+    >>> "No object found for UID" in test_utils.dispatch()
+    True
+    >>> len(queue.tasks)
+    0
+
+At this point, `IQueued` marker interface is no longer provided by Worksheet:
+
+     >>> IQueued.providedBy(worksheet)
+     False

--- a/src/senaite/queue/tests/doctests/WorksheetAnalysesAssign.rst
+++ b/src/senaite/queue/tests/doctests/WorksheetAnalysesAssign.rst
@@ -1,0 +1,371 @@
+Assignment of analyses to a Worksheet
+=====================================
+
+SENAITE Queue supports the `assign` transition for analyses, either for when
+the analyses are assigned manually (via `Add analyses` view from Worksheet) or
+when using a Worksheet Template.
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t WorksheetAnalysesAssign
+
+Test Setup
+----------
+
+Needed imports:
+
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+    >>> from senaite.queue import api
+    >>> from senaite.queue.interfaces import IQueued
+    >>> from senaite.queue.tests import utils as test_utils
+
+Functional Helpers:
+
+    >>> def new_samples(num_analyses):
+    ...     samples = []
+    ...     for num in range(num_analyses):
+    ...         sample = test_utils.create_sample([Cu], client, contact,
+    ...                                           sampletype, receive=True)
+    ...         samples.append(sample)
+    ...     return samples
+
+    >>> def get_analyses_from(samples):
+    ...     analyses = []
+    ...     for sample in samples:
+    ...         analyses.extend(sample.getAnalyses(full_objects=True))
+    ...     return analyses
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = api.get_setup()
+
+Create some basic objects for the test:
+
+    >>> setRoles(portal, TEST_USER_ID, ['Manager',])
+    >>> client = api.create(portal.clients, "Client", Name="Happy Hills", ClientID="HH", MemberDiscountApplies=True)
+    >>> contact = api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
+    >>> sampletype = api.create(setup.bika_sampletypes, "SampleType", title="Water", Prefix="W")
+    >>> labcontact = api.create(setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = api.create(setup.bika_departments, "Department", title="Chemistry", Manager=labcontact)
+    >>> category = api.create(setup.bika_analysiscategories, "AnalysisCategory", title="Metals", Department=department)
+    >>> Cu = api.create(setup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="15", Category=category.UID(), Accredited=True)
+
+Manual assignment of analyses to a Worksheet
+--------------------------------------------
+
+Set the number of analyses to be transitioned in a single queued task:
+
+    >>> task_name = "task_assign_analyses"
+    >>> api.set_chunk_size(task_name, 5)
+    >>> api.get_chunk_size(task_name)
+    5
+
+Create 15 Samples with 1 analysis each:
+
+    >>> samples = new_samples(15)
+    >>> analyses = get_analyses_from(samples)
+
+Create an empty worksheet and add all analyses:
+
+    >>> worksheet = api.create(portal.worksheets, "Worksheet")
+    >>> worksheet.addAnalyses(analyses)
+
+The worksheet provides now the interface `IQueued`:
+
+    >>> IQueued.providedBy(worksheet)
+    True
+
+Only the first chunk of analyses has been transitioned non-async:
+
+    >>> transitioned = test_utils.filter_by_state(analyses, "assigned")
+    >>> len(transitioned)
+    5
+
+And none of them provide the interface `IQueued`:
+
+    >>> any(map(lambda an: IQueued.providedBy(an), transitioned))
+    False
+
+While the rest of analyses, not yet transitioned, do provide `IQueued`:
+
+    >>> non_transitioned = test_utils.filter_by_state(analyses, "unassigned")
+    >>> len(non_transitioned)
+    10
+    >>> all(map(lambda an: IQueued.providedBy(an), non_transitioned))
+    True
+
+As the queue confirms:
+
+    >>> queue = test_utils.get_queue_tool()
+    >>> len(queue.tasks)
+    1
+    >>> queue.processed is None
+    True
+
+We manually trigger the queue dispatcher:
+
+    >>> response = test_utils.dispatch()
+    >>> "processed" in response
+    True
+
+And now, the queue has processed a new task:
+
+    >>> queue.processed is None
+    False
+
+But is not yet empty:
+
+    >>> queue.is_empty()
+    False
+
+The next chunk of analyses has been processed and only those that have been
+transitioned provide the interface `IQueued`:
+
+    >>> transitioned = test_utils.filter_by_state(analyses, "assigned")
+    >>> len(transitioned)
+    10
+    >>> non_transitioned = test_utils.filter_by_state(analyses, "unassigned")
+    >>> len(non_transitioned)
+    5
+    >>> any(map(lambda an: IQueued.providedBy(an), transitioned))
+    False
+    >>> all(map(lambda an: IQueued.providedBy(an), non_transitioned))
+    True
+
+Since there are still 5 analyses remaining, the Worksheet provides `IQueued`:
+
+    >>> IQueued.providedBy(worksheet)
+    True
+
+Change the number of items to process per task to 2:
+
+    >>> api.set_chunk_size(task_name, 2)
+    >>> api.get_chunk_size(task_name)
+    2
+
+And dispatch again:
+
+    >>> response = test_utils.dispatch()
+    >>> "processed" in response
+    True
+
+Now, only 2 analyses have been transitioned:
+
+    >>> transitioned = test_utils.filter_by_state(analyses, "assigned")
+    >>> len(transitioned)
+    12
+    >>> non_transitioned = test_utils.filter_by_state(analyses, "unassigned")
+    >>> len(non_transitioned)
+    3
+    >>> any(map(lambda an: IQueued.providedBy(an), transitioned))
+    False
+    >>> all(map(lambda an: IQueued.providedBy(an), non_transitioned))
+    True
+    >>> IQueued.providedBy(worksheet)
+    True
+
+As we've seen, the queue for this task is enabled:
+
+    >>> api.is_queue_enabled(task_name)
+    True
+
+But we can disable the queue for this task if we set the number of items to
+process per task to 0:
+
+    >>> api.disable_queue_for(task_name)
+    >>> api.is_queue_enabled(task_name)
+    False
+    >>> api.get_chunk_size(task_name)
+    0
+
+But still, if we manually trigger the dispatch with the queue being disabled,
+the action will take place. Thus, disabling the queue only prevents the system
+to add new tasks to the queue, but won't have effect to those that remain in
+the queue. Rather all remaining tasks will be processed in just one shot:
+
+    >>> response = test_utils.dispatch()
+    >>> "processed" in response
+    True
+    >>> queue.is_empty()
+    True
+    >>> transitioned = test_utils.filter_by_state(analyses, "assigned")
+    >>> len(transitioned)
+    15
+    >>> non_transitioned = test_utils.filter_by_state(analyses, "unassigned")
+    >>> len(non_transitioned)
+    0
+    >>> any(map(lambda an: IQueued.providedBy(an), transitioned))
+    False
+
+Since all analyses have been processed, the worksheet no longer provides the
+`IQueue` marker interface:
+
+    >>> IQueued.providedBy(worksheet)
+    False
+
+
+Assignment of analyses through Worksheet Template
+-------------------------------------------------
+
+Analyses can be assigned to a worksheet by making use of a Worksheet Template.
+In such case, the system must behave exactly the same way as before.
+
+Set the number of analyses to be transitioned in a single queued task:
+
+    >>> task_name = "task_assign_analyses"
+    >>> api.set_chunk_size(task_name, 5)
+    >>> api.get_chunk_size(task_name)
+    5
+
+Create 15 Samples with 1 analysis each:
+
+    >>> samples = new_samples(15)
+    >>> analyses = get_analyses_from(samples)
+
+Create a Worksheet Template with 15 slots reserved for `Cu` analysis:
+
+    >>> template = api.create(setup.bika_worksheettemplates, "WorksheetTemplate")
+    >>> template.setService([Cu])
+    >>> layout = map(lambda idx: {"pos": idx + 1, "type": "a"}, range(15))
+    >>> template.setLayout(layout)
+
+Use the template for Worksheet creation:
+
+    >>> worksheet = api.create(portal.worksheets, "Worksheet")
+    >>> worksheet.applyWorksheetTemplate(template)
+
+The worksheet provides now the interface `IQueued`:
+
+    >>> IQueued.providedBy(worksheet)
+    True
+
+Only the first chunk of analyses has been transitioned non-async:
+
+    >>> transitioned = test_utils.filter_by_state(analyses, "assigned")
+    >>> len(transitioned)
+    5
+
+And none of them provide the interface `IQueued`:
+
+    >>> any(map(lambda an: IQueued.providedBy(an), transitioned))
+    False
+
+While the rest of analyses, not yet transitioned, do provide `IQueued`:
+
+    >>> non_transitioned = test_utils.filter_by_state(analyses, "unassigned")
+    >>> len(non_transitioned)
+    10
+    >>> all(map(lambda an: IQueued.providedBy(an), non_transitioned))
+    True
+
+As the queue confirms:
+
+    >>> queue = test_utils.get_queue_tool()
+    >>> len(queue.tasks)
+    1
+    >>> queue.contains_tasks_for(worksheet)
+    True
+
+We manually trigger the queue dispatcher:
+
+    >>> response = test_utils.dispatch()
+    >>> "processed" in response
+    True
+
+And now, the queue has processed a new task but is not yet empty:
+
+    >>> queue.is_empty()
+    False
+    >>> queue.contains_tasks_for(worksheet)
+    True
+
+The next chunk of analyses has been processed and only those that have been
+transitioned provide the interface `IQueued`:
+
+    >>> transitioned = test_utils.filter_by_state(analyses, "assigned")
+    >>> len(transitioned)
+    10
+    >>> non_transitioned = test_utils.filter_by_state(analyses, "unassigned")
+    >>> len(non_transitioned)
+    5
+    >>> any(map(lambda an: IQueued.providedBy(an), transitioned))
+    False
+    >>> all(map(lambda an: IQueued.providedBy(an), non_transitioned))
+    True
+
+Since there are still 5 analyses remaining, the Worksheet provides `IQueued`:
+
+    >>> IQueued.providedBy(worksheet)
+    True
+
+Change the number of items to process per task to 2:
+
+    >>> api.set_chunk_size(task_name, 2)
+    >>> api.get_chunk_size(task_name)
+    2
+
+And dispatch again:
+
+    >>> response = test_utils.dispatch()
+    >>> "processed" in response
+    True
+
+Now, only 2 analyses have been transitioned:
+
+    >>> transitioned = test_utils.filter_by_state(analyses, "assigned")
+    >>> len(transitioned)
+    12
+    >>> non_transitioned = test_utils.filter_by_state(analyses, "unassigned")
+    >>> len(non_transitioned)
+    3
+    >>> any(map(lambda an: IQueued.providedBy(an), transitioned))
+    False
+    >>> all(map(lambda an: IQueued.providedBy(an), non_transitioned))
+    True
+    >>> IQueued.providedBy(worksheet)
+    True
+
+As we've seen, the queue for this task is enabled:
+
+    >>> api.is_queue_enabled(task_name)
+    True
+
+But we can disable the queue for this task if we set the number of items to
+process per task to 0:
+
+    >>> api.disable_queue_for(task_name)
+    >>> api.is_queue_enabled(task_name)
+    False
+    >>> api.get_chunk_size(task_name)
+    0
+
+But still, if we manually trigger the dispatch with the queue being disabled,
+the action will take place. Thus, disabling the queue only prevents the system
+to add new tasks to the queue, but won't have effect to those that remain in
+the queue. Rather all remaining tasks will be processed in just one shot:
+
+    >>> response = test_utils.dispatch()
+    >>> "processed" in response
+    True
+    >>> queue.is_empty()
+    True
+    >>> queue.contains_tasks_for(worksheet)
+    False
+    >>> transitioned = test_utils.filter_by_state(analyses, "assigned")
+    >>> len(transitioned)
+    15
+    >>> non_transitioned = test_utils.filter_by_state(analyses, "unassigned")
+    >>> len(non_transitioned)
+    0
+    >>> any(map(lambda an: IQueued.providedBy(an), transitioned))
+    False
+
+Since all analyses have been processed, the worksheet no longer provides the
+`IQueue` marker interface:
+
+    >>> IQueued.providedBy(worksheet)
+    False

--- a/src/senaite/queue/tests/utils.py
+++ b/src/senaite/queue/tests/utils.py
@@ -1,5 +1,4 @@
 from DateTime import DateTime
-from plone import api as ploneapi
 from senaite.queue import api
 from senaite.queue.storage import QueueStorageTool
 from senaite.queue.views.consumer import QueueConsumerView

--- a/src/senaite/queue/views/consumer.py
+++ b/src/senaite/queue/views/consumer.py
@@ -19,12 +19,13 @@
 # Some rights reserved, see README and LICENSE.
 
 from Products.Five.browser import BrowserView
-from bika.lims.interfaces import IWorksheet
 from senaite.queue import api
 from senaite.queue import logger
 from senaite.queue.interfaces import IQueuedTaskAdapter
 from senaite.queue.storage import QueueStorageTool
 from zope.component import queryAdapter
+
+from bika.lims.interfaces import IWorksheet
 
 
 class QueueConsumerView(BrowserView):
@@ -89,9 +90,10 @@ class QueueConsumerView(BrowserView):
 
         adapter = queryAdapter(task_context, IQueuedTaskAdapter, name=task.name)
         if adapter:
-            # Process the task
             logger.info("Processing task '{}' for '{}' ({}) ...".format(
                 task.name, api.get_id(task_context), task.context_uid))
+
+            # Process the task
             return adapter.process(task, self.request)
 
         logger.error("Adapter for task {} and context {} not found!"

--- a/src/senaite/queue/views/dispatcher.py
+++ b/src/senaite/queue/views/dispatcher.py
@@ -45,14 +45,6 @@ class QueueDispatcherView(BrowserView):
 
         # Get the queue from storage
         queue = QueueStorageTool()
-
-        # Check the speed on how new objects are added to the queue as an
-        # indicator of the overall activity of users. If the speed increases
-        # rapidly, better to slow down a bit the dispatcher to prevent users to
-        # experience db conflicts
-        #speed = queue.speed()
-        #logger.info("** SPEED: {}".format(speed))
-
         if not queue.lock():
             logger.info("Cannot lock the queue [SKIP]")
             return self.response("Cannot lock the queue", queue)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When a task fails, the system automatically re-queues the task. This Pull Request allows to define how many times the system will retry to process a task before considered as failed and removed from the queue.

This Pull Request also contains some improvements in the queue logic

## Current behavior before PR

Failing tasks are always re-queued

## Desired behavior after PR is merged

Failing tasks are re-queued until the `max_retries` value is reached 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
