### PR TITLE
Worksheets cannot transition if they have queued jobs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
+- #5 No actions can be done to worksheets with queued jobs
 
 1.0.1 (2020-02-09)
 ------------------

--- a/src/senaite/queue/adapters/configure.zcml
+++ b/src/senaite/queue/adapters/configure.zcml
@@ -101,6 +101,13 @@
     factory=".guards.SampleGuardAdapter"
     provides="bika.lims.interfaces.IGuardAdapter"/>
 
+  <!-- Worksheet cannot transition when queued analyses -->
+  <adapter
+    name="senaite.queue.worksheet_guard"
+    for="bika.lims.interfaces.IWorksheet"
+    factory=".guards.WorksheetGuardAdapter"
+    provides="bika.lims.interfaces.IGuardAdapter"/>
+
   <!-- Queued analyses: Add Analyses view from inside Worksheet.
   Analyses that are labeled with IQueued are not displayed -->
   <subscriber

--- a/src/senaite/queue/adapters/guards.py
+++ b/src/senaite/queue/adapters/guards.py
@@ -20,6 +20,7 @@
 
 from senaite.queue import api
 from senaite.queue.interfaces import IQueued
+from senaite.queue.storage import WorksheetQueueStorage
 from zope.interface import implements
 
 from bika.lims.interfaces import IGuardAdapter
@@ -38,4 +39,24 @@ class SampleGuardAdapter(object):
             analysis = api.get_object(brain)
             if IQueued.providedBy(analysis):
                 return False
+        return True
+
+
+class WorksheetGuardAdapter(object):
+    implements(IGuardAdapter)
+
+    def __init__(self, context):
+        self.context = context
+
+    def guard(self, action):
+        """Returns False if the worksheet has queued jobs
+        """
+        if IQueued.providedBy(self.context):
+            return False
+
+        # Check if there are queued jobs for this worksheet
+        storage = WorksheetQueueStorage(self.context)
+        if storage.uids:
+            return False
+
         return True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Ensure that Worksheets with queued jobs (e.g. analyses assignment, etc.) cannot transition before the queued tasks finish.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
