### PR TITLE
Allow the prioritization of tasks in the queue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
+- #6 Allow the prioritization of tasks
 - #5 No actions can be done to worksheets with queued jobs
 
 1.0.1 (2020-02-09)

--- a/src/senaite/queue/queue.py
+++ b/src/senaite/queue/queue.py
@@ -59,7 +59,8 @@ def queue_assign_analyses(worksheet, request, uids, slots, wst_uid=None):
     return queue_task("task_assign_analyses", request, worksheet)
 
 
-def queue_task(name, request, context, username=None, unique=False):
+def queue_task(name, request, context, username=None, unique=False,
+               priority=10):
     """Adds a task to general queue storage
     :param name: the name of the task
     :param request: the HTTPRequest
@@ -68,6 +69,8 @@ def queue_task(name, request, context, username=None, unique=False):
     :param unique: whether if only one task for the given name and context
     must be added. If True, the task will only be added if there is no other
     task with same name and context
+    :param priority: priority of this task over others. Lower values have more
+    priority over higher values
     """
     if not name:
         # Name is mandatory
@@ -78,7 +81,7 @@ def queue_task(name, request, context, username=None, unique=False):
         return False
 
     queue = QueueStorageTool()
-    task = QueueTask(name, request, context, tmpID())
+    task = QueueTask(name, request, context, tmpID(), priority=priority)
     if username:
         task.username = username
     return queue.append(task)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

At the moment, the system does not allow to prioritize tasks in the queue, so all tasks are processed on a first-in-first-out basis. This Pull Request allows the prioritization of tasks, so tasks are sorted (and processed) based on their priority.

## Current behavior before PR

No prioritization of tasks

## Desired behavior after PR is merged

Allow to prioritize tasks

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
