### PR TITLE
Status of running tasks are not updated in the client's local pool

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.0.3 (unreleased)
 ------------------
 
+- Fix client's queue tasks in "queued" status are not updated when "running"
 
 
 1.0.2 (2020-11-15)

--- a/src/senaite/queue/tests/doctests/ClientQueueUtility.rst
+++ b/src/senaite/queue/tests/doctests/ClientQueueUtility.rst
@@ -408,17 +408,41 @@ from the server's queue:
     >>> all(map(s_utility.has_task, utility.get_tasks()))
     True
 
-Delete the newly added task, so we keep only one task in the queue for testing:
+When the task status in the server is "running", the corresponding task of the
+local pool is always updated on synchronization:
 
-    >>> utility.delete(server_task)
+    >>> consumer_id = u'http://nohost'
+    >>> running = s_utility.pop(consumer_id)
+    >>> running.status
+    'running'
+
+    >>> local_task = utility.get_task(running.task_uid)
+    >>> local_task.status
+    'queued'
+
+    >>> utility.sync()
+    >>> local_task = utility.get_task(running.task_uid)
+    >>> local_task.status
+    'running'
+
+Flush the queue:
+
+    >>> deleted = map(utility.delete, utility.get_tasks())
     >>> len(utility)
-    1
+    0
     >>> len(s_utility)
-    1
+    0
 
 
 Pop a task
 ~~~~~~~~~~
+
+Add a new task to the queue:
+
+    >>> kwargs = {"action": "receive"}
+    >>> task = new_task("task_action_receive", sample, **kwargs)
+    >>> utility.add(task) == task
+    True
 
 When a task is popped, the utility changes the status of the task to "running",
 cause expects that the task has been popped for consumption:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Each zeo client keeps a local pool of tasks that regularly syncs with the queue server. The status of tasks from the local pool that are in "queued" status are never updated, even if the real status of the task in the server pool is "running".

This might lead to some problems with transitions when the client acts as a consumer too, cause there is a generic guard that prevents a task in "queued" to be transitioned. Since the client "thinks" the task is "queued" (instead of "running"), the guard returns False and the transition cannot take place.

This PR ensures that during the synchronization process (diff route), the server always return "running" tasks, even if client has them already on it's own local pool. On synchronization, client always drop local tasks that have returned by the server first. Therefore, the result is that the local task gets updated to "running" status.

## Current behavior before PR

The status of running tasks are not updated in the local pool

## Desired behavior after PR is merged

The status of running tasks are not updated in the local pool

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
