### PR TITLE
Support "receive" transition from samples' main listing

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,8 @@ Changelog
 1.0.3 (unreleased)
 ------------------
 
-- Fix client's queue tasks in "queued" status are not updated when "running"
+- #10 Support "receive" transition from samples' main listing
+- #9 Fix client's queue tasks in "queued" status are not updated when "running"
 
 
 1.0.2 (2020-11-15)

--- a/docs/doctests.rst
+++ b/docs/doctests.rst
@@ -11,3 +11,4 @@ Doctests
 .. include:: ../src/senaite/queue/tests/doctests/WorksheetAnalysesRetract.rst
 .. include:: ../src/senaite/queue/tests/doctests/WorksheetAnalysesVerify.rst
 .. include:: ../src/senaite/queue/tests/doctests/SampleWithQueuedAnalyses.rst
+.. include:: ../src/senaite/queue/tests/doctests/SamplesReceive.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ of transaction conflicts:
 * Assignment of worksheet template to a worksheet
 * Creation of a worksheet by using a worksheet template
 * Workflow actions (submit, verify, etc.) for analyses assigned to worksheets
+* Reception of selected samples from samples main listing
 * Recursive permissions assignment on client contacts creation
 
 This add-on neither provides support for workflow transitions/actions at Sample

--- a/src/senaite/queue/adapters/actions.py
+++ b/src/senaite/queue/adapters/actions.py
@@ -32,8 +32,7 @@ class WorkflowActionGenericQueueAdapter(WorkflowActionGenericAdapter):
 
         if api.is_queue_ready(action):
             # Add to the queue
-            kwargs = {"unique": True}
-            api.add_action_task(objects, action, self.context, **kwargs)
+            api.add_action_task(objects, action, self.context)
             return objects
 
         # Delegate to base do_action

--- a/src/senaite/queue/adapters/configure.zcml
+++ b/src/senaite/queue/adapters/configure.zcml
@@ -16,6 +16,13 @@
     provides="senaite.queue.interfaces.IQueuedTaskAdapter"
     for="*" />
 
+  <!-- Adapter for sample's workflow verify action -->
+  <adapter
+    name="task_action_verify"
+    factory=".QueuedActionTaskAdapter"
+    provides="senaite.queue.interfaces.IQueuedTaskAdapter"
+    for="bika.lims.interfaces.IAnalysisRequestsFolder" />
+
   <!-- Adapter for analyses action queue task -->
   <adapter
     name="task_action_submit"
@@ -103,6 +110,26 @@
   <adapter
     name="workflow_action_verify"
     for="bika.lims.interfaces.IWorksheet
+         senaite.queue.interfaces.ISenaiteQueueLayer"
+    factory=".actions.WorkflowActionGenericQueueAdapter"
+    provides="bika.lims.interfaces.IWorkflowActionAdapter"
+    permission="zope.Public" />
+
+  <!-- Samples folder: "receive"
+  Receive the selected samples by using the queue -->
+  <adapter
+    name="workflow_action_receive"
+    for="bika.lims.interfaces.IAnalysisRequestsFolder
+         senaite.queue.interfaces.ISenaiteQueueLayer"
+    factory=".actions.WorkflowActionGenericQueueAdapter"
+    provides="bika.lims.interfaces.IWorkflowActionAdapter"
+    permission="zope.Public" />
+
+  <!-- Samples folder: "verify"
+  Verify the selected samples by using the queue -->
+  <adapter
+    name="workflow_action_verify"
+    for="bika.lims.interfaces.IAnalysisRequestsFolder
          senaite.queue.interfaces.ISenaiteQueueLayer"
     factory=".actions.WorkflowActionGenericQueueAdapter"
     provides="bika.lims.interfaces.IWorkflowActionAdapter"

--- a/src/senaite/queue/tests/doctests/SamplesReceive.rst
+++ b/src/senaite/queue/tests/doctests/SamplesReceive.rst
@@ -1,0 +1,204 @@
+Receive Samples
+---------------
+
+SENAITE Queue supports the `receive` transition for samples selected from the
+samples listing.
+
+Running this test from the buildout directory:
+
+    bin/test test_textual_doctests -t SamplesReceive
+
+
+Test Setup
+~~~~~~~~~~
+
+Needed imports:
+
+    >>> import time
+    >>> import transaction
+    >>> from bika.lims import api as _api
+    >>> from plone import api as plone_api
+    >>> from plone.app.testing import setRoles
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+    >>> from senaite.queue import api
+    >>> from senaite.queue.tests import utils as test_utils
+    >>> from zope import globalrequest
+
+Functional Helpers:
+
+    >>> def new_samples(num_analyses):
+    ...     samples = []
+    ...     for num in range(num_analyses):
+    ...         sample = test_utils.create_sample([Cu], client, contact,
+    ...                                           sampletype, receive=False)
+    ...         samples.append(sample)
+    ...     transaction.commit()
+    ...     return samples
+
+Variables:
+
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> setup = _api.get_setup()
+    >>> browser = self.getBrowser()
+    >>> globalrequest.setRequest(request)
+    >>> setRoles(portal, TEST_USER_ID, ["LabManager", "Manager"])
+    >>> transaction.commit()
+
+Create some basic objects for the test:
+
+    >>> setRoles(portal, TEST_USER_ID, ['Manager',])
+    >>> client = _api.create(portal.clients, "Client", Name="Happy Hills", ClientID="HH", MemberDiscountApplies=True)
+    >>> contact = _api.create(client, "Contact", Firstname="Rita", Lastname="Mohale")
+    >>> sampletype = _api.create(setup.bika_sampletypes, "SampleType", title="Water", Prefix="W")
+    >>> labcontact = _api.create(setup.bika_labcontacts, "LabContact", Firstname="Lab", Lastname="Manager")
+    >>> department = _api.create(setup.bika_departments, "Department", title="Chemistry", Manager=labcontact)
+    >>> category = _api.create(setup.bika_analysiscategories, "AnalysisCategory", title="Metals", Department=department)
+    >>> Cu = _api.create(setup.bika_analysisservices, "AnalysisService", title="Copper", Keyword="Cu", Price="15", Category=category.UID(), Accredited=True)
+
+Setup the current instance as the queue server too:
+
+    >>> key = "senaite.queue.server"
+    >>> host = u'http://nohost/plone'
+    >>> plone_api.portal.set_registry_record(key, host)
+    >>> transaction.commit()
+
+
+Receive multiple samples at once
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Create 15 Samples with 1 analysis each:
+
+    >>> samples = new_samples(15)
+
+The samples are in `sample_due` status:
+
+    >>> len(test_utils.filter_by_state(samples, "sample_due"))
+    15
+
+Receive the samples (as if we selected them in Samples folder):
+
+    >>> folder = _api.get_portal().analysisrequests
+    >>> test_utils.handle_action(folder, samples, "receive")
+
+None of the samples have been transitioned yet:
+
+    >>> len(test_utils.filter_by_state(samples, "received"))
+    0
+
+The samples are now queued:
+
+    >>> all(map(api.is_queued, samples))
+    True
+
+The queue contains one task:
+
+    >>> queue = api.get_queue()
+    >>> queue.is_empty()
+    False
+
+    >>> len(queue)
+    1
+
+    >>> len(queue.get_tasks_for(folder))
+    1
+
+Pop a task and process:
+
+    >>> popped = queue.pop("http://nohost")
+    >>> test_utils.process(browser, popped.task_uid)
+    '{...Processed...}'
+
+The first chunk of samples has been processed:
+
+    >>> len(test_utils.filter_by_state(samples, "sample_received"))
+    10
+
+    >>> len(test_utils.filter_by_state(samples, "sample_due"))
+    5
+
+Pop and process again:
+
+    >>> popped = queue.pop("http://nohost")
+    >>> test_utils.process(browser, popped.task_uid)
+    '{...Processed...}'
+
+Remaining samples have been processed:
+
+    >>> len(test_utils.filter_by_state(samples, "sample_received"))
+    15
+
+    >>> len(test_utils.filter_by_state(samples, "sample_due"))
+    0
+
+    >>> any(map(api.is_queued, samples))
+    False
+
+And the queue is now empty:
+
+    >>> queue.is_empty()
+    True
+
+
+Receive multiple samples while adding more
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The "receive" action for Samples triggered from the samples listing is not
+treated as "unique" by the queue, so even if the system contains samples in
+the queue for reception already, the queue will keep accepting more tasks of
+this type.
+
+Create 5 Samples with 1 analysis each and receive them:
+
+    >>> folder = _api.get_portal().analysisrequests
+    >>> samples = new_samples(5)
+    >>> test_utils.handle_action(folder, samples, "receive")
+
+The queue contains one task for the samples folder context:
+
+    >>> queue = api.get_queue()
+    >>> len(queue.get_tasks_for(folder))
+    1
+
+Add 5 more Samples and receive them as well:
+
+    >>> samples2 = new_samples(5)
+    >>> test_utils.handle_action(folder, samples2, "receive")
+
+The queue contains now two tasks for the samples folder context:
+
+    >>> len(queue.get_tasks_for(folder))
+    2
+
+Pop a task and process:
+
+    >>> popped = queue.pop("http://nohost")
+    >>> test_utils.process(browser, popped.task_uid)
+    '{...Processed...}'
+
+One set of samples has been processed:
+
+    >>> all_samples = samples + samples2
+    >>> len(test_utils.filter_by_state(all_samples, "sample_received"))
+    5
+
+    >>> len(queue.get_tasks_for(folder))
+    1
+
+Pop a task and process:
+
+    >>> popped = queue.pop("http://nohost")
+    >>> test_utils.process(browser, popped.task_uid)
+    '{...Processed...}'
+
+The rest of samples have been processed too:
+
+    >>> len(test_utils.filter_by_state(all_samples, "sample_received"))
+    10
+
+And the queue is now empty:
+
+    >>> queue = api.get_queue()
+    >>> queue.is_empty()
+    True


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR enables queue support for the transition "receive" when triggered from the main samples listing. Samples to be received are added to the queue and the transition is done asynchronously by consumers.

This transition was not supported by queue by default, so receiving a lot of samples at same time on instances with high load, ended up freezing the instance and samples weren't transitioned at all because of transaction commit conflicts.

This PR also enables support for "verify" transition in samples listings. Although this transition is done automatically when all analyses from a sample are verified, this might be required in some instances that do not have analyses verification and sample verification transitions coupled.

## Current behavior before PR

queue is not used on "receive" transition for selected samples from main sample listing

## Desired behavior after PR is merged

queue is used on "receive" transition for selected samples from main sample listing

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
