### PR TITLE
Improve the reindex security objects process

### DIFF
--- a/src/senaite/queue/adapters/__init__.py
+++ b/src/senaite/queue/adapters/__init__.py
@@ -141,7 +141,7 @@ class QueueObjectSecurityAdapter(object):
         # Reindex the objects
         map(self.reindex_security, uids)
 
-        if oldest_uid != top_uid:
+        if top_uid not in uids:
             # We have not processed yet the top-level node, keep reindexing
             # further objects from the hierarchy tree
             kwargs = {

--- a/src/senaite/queue/api.py
+++ b/src/senaite/queue/api.py
@@ -296,7 +296,7 @@ def add_reindex_obj_security_task(brain_object_uid, **kwargs):
     task_name = "task_reindex_object_security"
     kwargs.update({
         "uids": uids,
-        "priority": kwargs.get("priority", 20),
+        "priority": kwargs.get("priority", 50),
         "chunk_size": chunk_size,
         "ghost": True,
     })

--- a/src/senaite/queue/api.py
+++ b/src/senaite/queue/api.py
@@ -229,7 +229,7 @@ def add_reindex_obj_security_task(brain_object_uid, **kwargs):
         if previous is None:
             previous = []
 
-        if len(previous >= max):
+        if len(previous) >= max:
             return previous
 
         # Get the ids of the children and sort them from newest to oldest

--- a/src/senaite/queue/api.py
+++ b/src/senaite/queue/api.py
@@ -225,33 +225,80 @@ def add_reindex_obj_security_task(brain_object_uid, **kwargs):
     :return: the task added to the queue
     :rtype: senaite.queue.queue.QueueTask
     """
-    def get_children_uids(base_obj):
-        """Returns the uids from the obj hierarchy
-        """
-        if not hasattr(aq_base(base_obj), "objectValues"):
-            return []
+    def walk_down(obj, max=10, previous=None):
+        if previous is None:
+            previous = []
 
-        all_children = []
-        for child_obj in base_obj.objectValues():
-            all_children.extend(get_children_uids(child_obj))
-            all_children.append(_api.get_uid(child_obj))
+        if len(previous >= max):
+            return previous
 
-        return all_children
+        # Get the ids of the children and sort them from newest to oldest
+        child_ids = obj.objectIds()[::-1]
+
+        # We do not want more than the max number of objects specified
+        for child_id in child_ids:
+            child_obj = obj._getOb(child_id)
+            previous = walk_down(child_obj, max=max, previous=previous)
+            if len(previous) >= max:
+                return previous
+
+        previous.append(_api.get_uid(obj))
+        return previous[:max]
+
+    def walk_up(obj, max=10, previous=None):
+        if previous is None:
+            previous = []
+
+        if len(previous) >= max:
+            return previous
+
+        previous.append(_api.get_uid(obj))
+
+        # Navigate to parent node
+        parent = _api.get_parent(obj)
+
+        # Check if this parent node has children not yet processed
+        ids = parent.objectIds()
+        obj_id = _api.get_id(obj)
+        obj_idx = ids.index(obj_id)
+        if obj_idx > 0:
+            # Current obj is not the oldest. Extract the items to process from
+            # younger siblings
+            younger = ids[:obj_idx][::-1]
+            for sibling_id in younger:
+                sibling = parent._getObj(sibling_id)
+                previous = walk_down(sibling, max=max, previous=previous)
+                if len(previous) >= max:
+                    return previous
+
+        previous.append(_api.get_uid(parent))
+        return previous[:max]
 
     # Get the object
     obj = _api.get_object(brain_object_uid)
+    obj_uid = _api.get_uid(obj)
 
-    # Get all children reversed, and append current one
-    uids = get_children_uids(obj)
-    uids.append(_api.get_uid(obj))
+    chunk_size = kwargs.get("chunk_size", 10)
+    top_uid = kwargs.get("top_uid")
+    if not top_uid:
+        kwargs.update({
+            "top_uid": _api.get_uid(obj)
+        })
 
-    # Get all reversed, so recent objects are processed first
-    uids = uids[::-1]
+        # Pick the newest and deepest leaf
+        leaves = walk_down(obj, max=1) or [obj_uid]
+        obj = _api.get_object_by_uid(leaves[0])
+
+    # We assume obj is the last deepest object not yet processed, extract the
+    # next objects to process that are above this obj from the tree hierarchy
+    uids = walk_up(obj, max=chunk_size)
 
     task_name = "task_reindex_object_security"
     kwargs.update({
         "uids": uids,
-        "priority": kwargs.get("priority", 20)
+        "priority": kwargs.get("priority", 20),
+        "chunk_size": chunk_size,
+        "ghost": True,
     })
     return add_task(task_name, obj, **kwargs)
 

--- a/src/senaite/queue/api.py
+++ b/src/senaite/queue/api.py
@@ -271,7 +271,7 @@ def add_reindex_obj_security_task(brain_object_uid, **kwargs):
                 if len(previous) >= max:
                     return previous
 
-        previous.append(_api.get_uid(parent))
+        previous = walk_up(parent, max=max, previous=previous)
         return previous[:max]
 
     # Get the object

--- a/src/senaite/queue/api.py
+++ b/src/senaite/queue/api.py
@@ -266,7 +266,7 @@ def add_reindex_obj_security_task(brain_object_uid, **kwargs):
             # younger siblings
             younger = ids[:obj_idx][::-1]
             for sibling_id in younger:
-                sibling = parent._getObj(sibling_id)
+                sibling = parent._getOb(sibling_id)
                 previous = walk_down(sibling, max=max, previous=previous)
                 if len(previous) >= max:
                     return previous


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When granting or removing access to contacts, the system must apply new permissions to all objects from the hierarchy starting from the client the contact belongs to. 

Until now, this process has been handled by the queue following a "classic" strategy, so the system retrieves all child nodes from the client, get their uids and generate a task with all them. This task is then processed sequentially in chunks. There are two main problems with this approach:

1) When the user submits the form, the system needs to wake-up all objects from the hierarchy
2) The created task contains a list with all children UIDs from the hierarchy. This may cause consumers or even regular clients to not be able to obtain the queued tasks anymore.

This Pull Request follows a different approach, so the queue keeps walking through the hierarchy as required until all objects are processed. Tasks with a list of only 10 uids are used.

## Current behavior before PR

The reindex security objects process was making the queue to freeze

## Desired behavior after PR is merged

The reindex security objects process does not make the queue to freeze

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
