### PR TITLE
Use intial task's default chunk size when creating subsequent tasks

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+
+1.0.4 (unreleased)
+------------------
+
+- #14 Use intial task's default chunk size when creating subsequent tasks
+
+
 1.0.3 (2021-07-24)
 ------------------
 

--- a/src/senaite/queue/queue.py
+++ b/src/senaite/queue/queue.py
@@ -271,7 +271,7 @@ def get_chunks_for(task, items=None):
     if items is None:
         items = task.get("uids", [])
 
-    chunk_size = get_chunk_size(task.name)
+    chunk_size = task.get("chunk_size", get_chunk_size(task.name))
     return get_chunks(items, chunk_size)
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request guarantees that the chunk size of the initial task is preserved when creating derived tasks.

## Current behavior before PR

System only relies on system settings to establish the chunk size for a given task

## Desired behavior after PR is merged

System relies on the initial task to establish the chunk size for a new task

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
