### PR TITLE
Fix traceback on tasks for the reindex of objects security

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.0.4 (unreleased)
 ------------------
 
+- #15 Fix traceback on tasks for the reindex of objects security
 - #14 Use intial task's default chunk size when creating subsequent tasks
 
 

--- a/src/senaite/queue/api.py
+++ b/src/senaite/queue/api.py
@@ -245,7 +245,7 @@ def add_reindex_obj_security_task(brain_object_uid, **kwargs):
         previous.append(_api.get_uid(obj))
         return previous[:max]
 
-    def walk_up(obj, max=10, previous=None):
+    def walk_up(obj, top_obj_uid, max=10, previous=None):
         if previous is None:
             previous = []
 
@@ -271,7 +271,12 @@ def add_reindex_obj_security_task(brain_object_uid, **kwargs):
                 if len(previous) >= max:
                     return previous
 
-        previous = walk_up(parent, max=max, previous=previous)
+        parent_uid = _api.get_uid(parent)
+        root_uid = _api.get_uid(top_obj_uid)
+        if parent_uid != root_uid:
+            # We haven't arrived to the top of the hierarchy yet
+            previous = walk_up(parent, top_uid, max=max, previous=previous)
+
         return previous[:max]
 
     # Get the object
@@ -281,8 +286,9 @@ def add_reindex_obj_security_task(brain_object_uid, **kwargs):
     chunk_size = kwargs.get("chunk_size", 10)
     top_uid = kwargs.get("top_uid")
     if not top_uid:
+        top_uid = _api.get_uid(obj)
         kwargs.update({
-            "top_uid": _api.get_uid(obj)
+            "top_uid": top_uid
         })
 
         # Pick the newest and deepest leaf
@@ -291,7 +297,7 @@ def add_reindex_obj_security_task(brain_object_uid, **kwargs):
 
     # We assume obj is the last deepest object not yet processed, extract the
     # next objects to process that are above this obj from the tree hierarchy
-    uids = walk_up(obj, max=chunk_size)
+    uids = walk_up(obj, top_uid, max=chunk_size)
 
     task_name = "task_reindex_object_security"
     kwargs.update({


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes a traceback that arises on tasks for the reindex of objects security because of no ceiling when walking up to find nodes.

## Current behavior before PR


```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.contact, line 62, in __call__
  Module bika.lims.browser.contact, line 186, in _link_user
  Module bika.lims.content.contact, line 143, in setUser
  [...]
  Module senaite.queue.api, line 294, in add_reindex_obj_security_task
  Module senaite.queue.api, line 274, in walk_up
  Module senaite.queue.api, line 274, in walk_up
  Module senaite.queue.api, line 270, in walk_up
  Module senaite.queue.api, line 245, in walk_down
  Module bika.lims.api, line 429, in get_uid
  Module bika.lims.api, line 239, in get_object
  Module bika.lims.api, line 202, in fail
APIError: <AuditLogCatalog at /senaite/auditlog_catalog> is not supported.
```

## Desired behavior after PR is merged

No error

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
