### PR TITLE
Preserve task properties when requeueing chunks of action tasks

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,8 +5,9 @@ Changelog
 1.0.4 (unreleased)
 ------------------
 
+- #16 Preserve task properties when requeueing chunks of action tasks
 - #15 Fix traceback on tasks for the reindex of objects security
-- #14 Use intial task's default chunk size when creating subsequent tasks
+- #14 Use initial task's default chunk size when creating subsequent tasks
 
 
 1.0.3 (2021-07-24)

--- a/src/senaite/queue/adapters/__init__.py
+++ b/src/senaite/queue/adapters/__init__.py
@@ -51,8 +51,12 @@ class QueuedActionTaskAdapter(object):
         objects = map(_api.get_object_by_uid, chunks[0])
         map(lambda obj: doActionFor(obj, task["action"]), objects)
 
-        # Add remaining objects to the queue
-        api.add_action_task(chunks[1], task["action"], self.context)
+        # Add remaining objects to the queue and keep properties
+        keep = ["min_seconds", "max_seconds", "priority", "unique",
+                "chunk_size", "username", "ghost", "delay"]
+        keep = filter(lambda key: key in keep, task.keys())
+        kwargs = dict([(key, task[key]) for key in keep])
+        api.add_action_task(chunks[1], task["action"], self.context, **kwargs)
 
 
 class QueuedAssignAnalysesTaskAdapter(object):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request preserves the task properties when further chunks of an action task are queued

## Current behavior before PR

Task properties are not preserved when requeueing chunks of action tasks

## Desired behavior after PR is merged

Task properties are preserved when requeueing chunks of action tasks

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
