### PR TITLE
Fix tasks splits for generic actions are not created

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.0.4 (unreleased)
 ------------------
 
+- #17 Fix task splits are not being generated for generic actions
 - #16 Preserve task properties when requeueing chunks of action tasks
 - #15 Fix traceback on tasks for the reindex of objects security
 - #14 Use initial task's default chunk size when creating subsequent tasks

--- a/src/senaite/queue/server/utility.py
+++ b/src/senaite/queue/server/utility.py
@@ -384,10 +384,16 @@ class ServerQueueUtility(object):
                         .format(task.name, task.task_short_uid))
             return None
 
-        # Do not add the task if unique and task for same context and name
+        # Do not add the task if unique and task for same context and name,
+        # but do not consider tasks that are either failed or are currently
+        # running. Otherwise, system won't be able to add task splits within
+        # the same queue process life-cycle
         if task.get("unique", False):
+            skip = ["failed", "running"]
             query = {"context_uid": task.context_uid, "name": task.name}
-            if self.search(query):
+            existing = self.search(query)
+            existing = filter(lambda t: t.status not in skip, existing)
+            if existing:
                 logger.debug("Task {} for {} in the queue already".format(
                         task.name, task.context_path))
                 return None


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes an issue introduced with #16 that made the system to not create splited queued tasks from generic actions as expected.

With #16 the task properties are preserved from the main task across their "children" (or "splits").  One of the properties preserved is `unique`. This parameter `unique` ensures that the task won't be added into the queue unless no other task for same context (e.g. the object the action belongs to - worksheet if the action 'verify' is done inside a worksheet) exists. 

The `unique` parameter for generic action tasks that are handled directly by `senaite.queue` is always set by default to `True`: https://github.com/senaite/senaite.queue/blob/1.x/src/senaite/queue/adapters/actions.py#L35-L36

Therefore, system was trying to add a new task while preserving the flag `unique=True` . However, the previous task (the one from which the splits had to be generated) wasn't been removed yet from the queue. As a result, the new task was not not created, but the original one was removed later as part of the queue process life-cycle. 

This Pull Request ensures that `unique` parameter is only considered for tasks their status is neither `running` nor `failed`.

## Current behavior before PR

Queue tasks for generic actions are not splited in smaller chunks

## Desired behavior after PR is merged

Queue tasks for generic actions are splited in smaller chunks

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
