### PR TITLE
New `add_copy` function to add copies of existing tasks

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.0.4 (unreleased)
 ------------------
 
+- #18 New `add_copy` function to add copies of existing tasks
 - #17 Fix task splits are not being generated for generic actions
 - #16 Preserve task properties when requeueing chunks of action tasks
 - #15 Fix traceback on tasks for the reindex of objects security

--- a/src/senaite/queue/adapters/__init__.py
+++ b/src/senaite/queue/adapters/__init__.py
@@ -52,11 +52,7 @@ class QueuedActionTaskAdapter(object):
         map(lambda obj: doActionFor(obj, task["action"]), objects)
 
         # Add remaining objects to the queue and keep properties
-        keep = ["min_seconds", "max_seconds", "priority", "unique",
-                "chunk_size", "username", "ghost", "delay"]
-        keep = filter(lambda key: key in keep, task.keys())
-        kwargs = dict([(key, task[key]) for key in keep])
-        api.add_action_task(chunks[1], task["action"], self.context, **kwargs)
+        api.add_copy(task, context=self.context, uids=chunks[1], unique=False)
 
 
 class QueuedAssignAnalysesTaskAdapter(object):

--- a/src/senaite/queue/adapters/actions.py
+++ b/src/senaite/queue/adapters/actions.py
@@ -32,8 +32,7 @@ class WorkflowActionGenericQueueAdapter(WorkflowActionGenericAdapter):
 
         if api.is_queue_ready(action):
             # Add to the queue
-            kwargs = {"unique": True}
-            api.add_action_task(objects, action, self.context, **kwargs)
+            api.add_action_task(objects, action, self.context, unique=True)
             return objects
 
         # Delegate to base do_action

--- a/src/senaite/queue/api.py
+++ b/src/senaite/queue/api.py
@@ -170,6 +170,44 @@ def add_task(name, context, **kwargs):
     return get_queue().add(task)
 
 
+def add_copy(source_task, **kwargs):
+    """Adds a copy of the given task to the queue, but with attributes
+    overwritten by those from **kwargs
+    :param source_task: task to create a copy from
+    :param min_seconds: (optional) int, minimum seconds to book for the task
+    :param max_seconds: (optional) int, maximum seconds to wait for the task
+    :param retries: (optional) int, maximum number of retries on failure
+    :param username: (optional) str, the name of the user assigned to the task
+    :param priority: (optional) int, the priority value for this task
+    :param unique: (optional) bool, if True, the task will only be added if
+            there is no other task with same name and for same context. This
+            setting is set to False by default
+    :param chunk_size: (optional) the number of items to process asynchronously
+            at once from this task (if it contains multiple elements)
+    :param ghost: (optional) if True, clients won't get notified about the task
+            but consumers only. This setting is set to False by default
+    :param delay: (optional) delay in seconds before the task becomes available
+            for processing to consumers. Default: 0
+    :return: the QueueTask object added to the queue, if any
+    :rtype: senaite.queue.queue.QueueTask
+    :return: senaite.queue.queue.QueueTask
+    """
+    # update with additional attributes
+    source = dict(source_task)
+    source.update(kwargs)
+
+    # create the task
+    name = source.pop("name")
+    uid = source.pop("context_uid", None)
+    context = source.pop("context", None)
+    if not context:
+        context = _api.get_object_by_uid(uid)
+    task = new_task(name, context, **source)
+
+    # add the task to the queue and return
+    return get_queue().add(task)
+
+
 def add_action_task(brain_object_uid, action, context=None, **kwargs):
     """Adds an action-type task to the queue for async processing.
     :param brain_object_uid: object(s) to perform the action against

--- a/src/senaite/queue/queue.py
+++ b/src/senaite/queue/queue.py
@@ -178,11 +178,12 @@ def new_task(name, context, **kw):
     # skip attrs that are assigned on creation or belong to queue workflow
     skip = ["task_uid", "name", "request", "context_uid", "context_path",
             "created", "status", "error_message"]
+    kwargs = dict(kw)
     for attr_name in skip:
-        kw.pop(attr_name, None)
+        kwargs.pop(attr_name, None)
 
     # Create the Queue Task
-    task = QueueTask(name, api.get_request(), context, **kw)
+    task = QueueTask(name, api.get_request(), context, **kwargs)
 
     # Set the username (if provided in kw)
     task.username = kw.get("username", task.username)

--- a/src/senaite/queue/queue.py
+++ b/src/senaite/queue/queue.py
@@ -175,13 +175,14 @@ def new_task(name, context, **kw):
     :return: :class:`QueueTask <QueueTask>`
     :rtype: senaite.queue.queue.QueueTask
     """
-    # Skip attrs that are assigned when the QueueTask is instantiated
-    exclude = ["task_uid", "name", "request", "context_uid", "context_path"]
-    out_keys = filter(lambda k: k not in exclude, kw.keys())
-    kwargs = dict(map(lambda k: (k, kw[k]), out_keys))
+    # skip attrs that are assigned on creation or belong to queue workflow
+    skip = ["task_uid", "name", "request", "context_uid", "context_path",
+            "created", "status", "error_message"]
+    for attr_name in skip:
+        kw.pop(attr_name, None)
 
     # Create the Queue Task
-    task = QueueTask(name, api.get_request(), context, **kwargs)
+    task = QueueTask(name, api.get_request(), context, **kw)
 
     # Set the username (if provided in kw)
     task.username = kw.get("username", task.username)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request adds the function `add_copy` to make the addition of tasks that are copies or partial copies of existing tasks easier.

## Current behavior before PR

The addition of copies of tasks is not easy

## Desired behavior after PR is merged

The addition of copies of tasks is easy

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
