### PR TITLE
Fix APIError when processing orphan UIDs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 1.0.4 (unreleased)
 ------------------
 
+- #19 Fix APIError when processing orphan UIDs
 - #18 New `add_copy` function to add copies of existing tasks
 - #17 Fix task splits are not being generated for generic actions
 - #16 Preserve task properties when requeueing chunks of action tasks

--- a/src/senaite/queue/adapters/__init__.py
+++ b/src/senaite/queue/adapters/__init__.py
@@ -48,7 +48,8 @@ class QueuedActionTaskAdapter(object):
         chunks = get_chunks_for(task)
 
         # Process the first chunk
-        objects = map(_api.get_object_by_uid, chunks[0])
+        objects = [_api.get_object_by_uid(uid, None) for uid in chunks[0]]
+        objects = filter(None, objects)
         map(lambda obj: doActionFor(obj, task["action"]), objects)
 
         # Add remaining objects to the queue and keep properties


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes an APIError that occurs when the system tries to process a UID that do no longer have an object counterpart.

## Current behavior before PR

```
Traceback (most recent call last):
  File "/home/senaite/senaite/src/senaite.queue/src/senaite/queue/request.py", line 114, in wrapper
    return func(*args, **kwargs)
  File "/home/senaite/senaite/src/senaite.queue/src/senaite/queue/client/routes.py", line 97, in process
    adapter.process(task)
  File "/home/senaite/senaite/src/senaite.queue/src/senaite/queue/adapters/__init__.py", line 51, in process
    objects = map(_api.get_object_by_uid, chunks[0])
  File "/home/senaite/senaite/src/senaite.core/bika/lims/api/__init__.py", line 497, in get_object_by_uid
    fail("No object found for UID {}".format(uid))
  File "/home/senaite/senaite/src/senaite.core/bika/lims/api/__init__.py", line 204, in fail
    raise APIError("{}".format(msg))
APIError: No object found for UID 6c90078261a242db9075ee8bb732d79f
```


## Desired behavior after PR is merged

Orphan UIDs are skipped and task success gracefully

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
